### PR TITLE
Add Mono to the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,13 @@ RUN cd /opt \
   && cabal install -j \
   && ln -sf /opt/idris-cil/.cabal-sandbox/bin/idris-codegen-cil /usr/local/bin
 
+# Mono
+# http://www.mono-project.com/download/#download-lin
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
+  && (echo "deb http://download.mono-project.com/repo/ubuntu xenial main" | tee /etc/apt/sources.list.d/mono-official.list) \
+  && apt-get update \
+  && apt-get install -y mono-devel=5.2.0.215-0xamarin10+ubuntu1604b1
+
 # stuff in the data dir is likely to change very frequently but doesnt actually affect the image much itself,
 # example: version SHAs
 # So adding it last should speed up the builds

--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,16 @@ images/idris-cil-build-${BASE_TAG}.tar.gz: build
 
 image: images/idris-cil-build-${BASE_TAG}.tar.gz
 
+# The hashes calculated for ADD and COPY content seem to be different
+# on different platforms, so the "${REPO}:${BASE_TAG}" image
+# doesnt serve as a useful cache on some local dev machines
+local-cache:
+	docker pull "${REPO}:${BASE_TAG}" || true
+	docker build --cache-from "${REPO}:${BASE_TAG}" --tag "${REPO}:local_cache" .
+	docker image save -o "images/local-cache.tar" "${REPO}:local_cache"
+	cd images && gzip -v "local-cache.tar"
+
+quick:
+	docker build --cache-from "${REPO}:local_cache" .
+
 all: build image

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Built images are available on [DockerHub](https://hub.docker.com/r/irreverentpix
 Includes:
 
 - [`bamboo/idris-cil`](https://github.com/bamboo/idris-cil), commit SHA [`00e977f`](https://github.com/bamboo/idris-cil/commit/00e977f7619041c6fa4b927d3ca0fd0ab397d9af)
+- `mono-devel 5.2.0.215-0xamarin10+ubuntu1604b1`
 
 Along for the ride:
 


### PR DESCRIPTION
Technically not required for the build but a handy tool nonetheless if the build involves other code or for running tests as part of the build

-----

- Dockerfile
  - install mono